### PR TITLE
s3 logic in base/message

### DIFF
--- a/lib/queuel/base/engine.rb
+++ b/lib/queuel/base/engine.rb
@@ -32,6 +32,21 @@ module Queuel
       def client_klass
         raise NotImplementedError, "Must define a Queue class"
       end
+
+      def try_load(klass, gem_name)
+        if defined?(klass)
+          klass
+        else
+          begin
+            logger.info "Loading #{klass}..."
+            require gem_name
+            klass
+          rescue LoadError
+            logger.error "Couldn't find #{gem_name} gem"
+          end
+        end
+      end
+
     end
   end
 end

--- a/lib/queuel/base/message.rb
+++ b/lib/queuel/base/message.rb
@@ -76,6 +76,67 @@ module Queuel
       def decode_body?
         !decoder.nil? && decode? && raw_body.is_a?(String)
       end
+
+      def max_bytesize
+        options[:max_bytesize] || 64 * 1024
+      end
+
+      def push_message_body
+        if encoded_body.bytesize > max_bytesize
+          key = generate_key
+          s3_transaction(:write, key, encoded_body)
+          self.body = { 'queuel_s3_object' => key }
+        end
+        encoded_body
+      end
+
+      def pull_message_body
+        raise NotImplementedError, "must define method #pull_message_body"
+      end
+
+      def s3
+        @s3 ||= ::AWS::S3.new(
+                  :access_key_id => options[:s3_access_key_id],
+                  :secret_access_key => options[:s3_secret_access_key] )
+      end
+
+      # @method - write or read
+      # @args - key and message if writing
+      def s3_transaction(method, *args)
+        bucket_name = options[:s3_bucket_name]
+        raise NoBucketNameSupplied if bucket_name.nil?
+        my_bucket = s3.buckets[bucket_name]
+        if my_bucket.exists?
+          begin
+            send("s3_#{method}", my_bucket, *args)
+          rescue AWS::S3::Errors::AccessDenied => e
+            raise InsufficientPermissions, "Unable to read from bucket: #{e.message}"
+          end
+        else
+          raise BucketDoesNotExistError, "Bucket has either expired or does not exist"
+        end
+      end
+
+      def s3_read(bucket, *args)
+        bucket.objects[args[0]].read
+      end
+
+      def s3_write(bucket, *args)
+        bucket.objects[args[0]].write(args[1])
+      end
+
+      def generate_key
+        key = [
+          (Time.now.to_f * 10000).to_i,
+          SecureRandom.urlsafe_base64,
+          Thread.current.object_id
+        ].join('-')
+        key
+      end
+
+      class NoBucketNameSupplied < Exception; end
+      class InsufficientPermissions < StandardError; end
+      class BucketDoesNotExistError < StandardError; end
     end
   end
 end

--- a/lib/queuel/iron_mq/message.rb
+++ b/lib/queuel/iron_mq/message.rb
@@ -2,13 +2,23 @@ module Queuel
   module IronMq
     class Message < Base::Message
       def raw_body
-        @raw_body ||
-          (message_object && message_object.body) ||
-          encoded_body
+        @raw_body ||= message_object ? pull_message_body : push_message_body
       end
 
       def delete
         message_object.delete
+      end
+
+      def pull_message_body
+        begin
+          decoded_body = decoder.call(message_object.body)
+          if decoded_body.key?(:queuel_s3_object)
+            return s3_transaction(:read, decoded_body[:queuel_s3_object])
+          end
+        rescue Queuel::Serialization::Json::SerializationError, TypeError
+          # do nothing
+        end
+        message_object.body
       end
 
       [:id, :queue].each do |delegate|

--- a/lib/queuel/sqs/engine.rb
+++ b/lib/queuel/sqs/engine.rb
@@ -13,20 +13,8 @@ module Queuel
 
       private
 
-
       def client_klass
-        if defined?(::AWS::SQS)
-          ::AWS::SQS
-        else
-          begin
-            logger.info "Loading AWS SDK..."
-            require 'aws-sdk'
-            ::AWS::SQS
-          rescue LoadError
-            logger.error "Couldn't find aws_sdk gem"
-            raise(AWSSDKMissingError)
-          end
-        end
+        try_load(::AWS::SQS, 'aws-sdk')
       end
     end
   end

--- a/lib/queuel/sqs/message.rb
+++ b/lib/queuel/sqs/message.rb
@@ -3,7 +3,7 @@ module Queuel
     class Message < Base::Message
 
       def raw_body
-        @raw_body ||= message_object ? pull_message : push_message
+        @raw_body ||= message_object ? pull_message_body : push_message_body
       end
 
       def delete
@@ -16,17 +16,7 @@ module Queuel
         end
       end
 
-      def push_message
-        if encoded_body.bytesize > max_bytesize
-          key = generate_key
-          s3_transaction(:write, key, encoded_body)
-          self.body = { 'queuel_s3_object' => key }
-        end
-        encoded_body
-      end
-      private :push_message
-
-      def pull_message
+      def pull_message_body
         begin
           decoded_body = decoder.call(message_object.body)
           if decoded_body.key?(:queuel_s3_object)
@@ -38,57 +28,6 @@ module Queuel
           raw_body_with_sns_check
         end
       end
-      private :pull_message
-
-      def max_bytesize
-        options[:max_bytesize] || 64 * 1024
-      end
-      private :max_bytesize
-
-      def s3
-        @s3 ||= ::AWS::S3.new(
-                  :access_key_id => options[:s3_access_key_id],
-                  :secret_access_key => options[:s3_secret_access_key] )
-      end
-      private :s3
-
-      # @method - write or read
-      # @args - key and message if writing
-      def s3_transaction(method, *args)
-        bucket_name = options[:s3_bucket_name]
-        raise NoBucketNameSupplied if bucket_name.nil?
-        my_bucket = s3.buckets[bucket_name]
-        if my_bucket.exists?
-          begin
-            send("s3_#{method}", my_bucket, *args)
-          rescue AWS::S3::Errors::AccessDenied => e
-            raise InsufficientPermissions, "Unable to read from bucket: #{e.message}"
-          end
-        else
-          raise BucketDoesNotExistError, "Bucket has either expired or does not exist"
-        end
-      end
-      private :s3_transaction
-
-      def s3_read(bucket, *args)
-        bucket.objects[args[0]].read
-      end
-      private :s3_read
-
-      def s3_write(bucket, *args)
-        bucket.objects[args[0]].write(args[1])
-      end
-      private :s3_write
-
-      def generate_key
-        key = [
-          (Time.now.to_f * 10000).to_i,
-          SecureRandom.urlsafe_base64,
-          Thread.current.object_id
-        ].join('-')
-        key
-      end
-      private :generate_key
 
       def raw_body_with_sns_check
         begin
@@ -98,11 +37,6 @@ module Queuel
         end
       end
       private :raw_body_with_sns_check
-
-
-      class NoBucketNameSupplied < Exception; end
-      class InsufficientPermissions < StandardError; end
-      class BucketDoesNotExistError < StandardError; end
     end
   end
 end


### PR DESCRIPTION
IronMQ (and any engine added in the future) can now use the s3 fallback for oversized messages.

This addresses issue #29