### PR TITLE
Up SQS Max Message to 256kb

### DIFF
--- a/.octopolo.yml
+++ b/.octopolo.yml
@@ -1,0 +1,1 @@
+github_repo: sportngin/queuel

--- a/lib/queuel/sqs/message.rb
+++ b/lib/queuel/sqs/message.rb
@@ -2,6 +2,10 @@ module Queuel
   module SQS
     class Message < Base::Message
 
+      def self.max_known_byte_size
+        256
+      end
+
       def raw_body
         @raw_body ||= message_object ? pull_message : push_message
       end
@@ -41,7 +45,7 @@ module Queuel
       private :pull_message
 
       def max_bytesize
-        options[:max_bytesize] || 64 * 1024
+        options[:max_bytesize] || Queuel::SQS::Message.max_known_byte_size * 1024
       end
       private :max_bytesize
 

--- a/lib/queuel/sqs/message.rb
+++ b/lib/queuel/sqs/message.rb
@@ -2,9 +2,7 @@ module Queuel
   module SQS
     class Message < Base::Message
 
-      def self.max_known_byte_size
-        256
-      end
+      MAX_KNOWN_BYTE_SIZE = 265
 
       def raw_body
         @raw_body ||= message_object ? pull_message : push_message
@@ -45,7 +43,7 @@ module Queuel
       private :pull_message
 
       def max_bytesize
-        options[:max_bytesize] || Queuel::SQS::Message.max_known_byte_size * 1024
+        options[:max_bytesize] || Queuel::SQS::Message::MAX_KNOWN_BYTE_SIZE * 1024
       end
       private :max_bytesize
 


### PR DESCRIPTION
Description and Impact
----------------------
Ups max byte size to 256kb.

Deploy Plan
-----------
> Does Infrastructure need to know anything special about this deploy?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below. Review [QA Best Practices](https://source.sportngin.com/page/show/1227795-qa-best-practices).

#### Happy Path Scenarios
* Ensure a large message will be pushed to SQS for a properly configured queuel.
