### PR TITLE
Fix Queuel Max SQS Message Size

### DIFF
--- a/lib/queuel/sqs/message.rb
+++ b/lib/queuel/sqs/message.rb
@@ -2,7 +2,7 @@ module Queuel
   module SQS
     class Message < Base::Message
 
-      MAX_KNOWN_BYTE_SIZE = 265
+      MAX_KNOWN_BYTE_SIZE = 256
 
       def raw_body
         @raw_body ||= message_object ? pull_message : push_message


### PR DESCRIPTION
Description and Impact
----------------------
Max SQS message size should be 256kb not 265kb

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below. Review [QA Best Practices](https://source.sportngin.com/page/show/1227795-qa-best-practices).

#### Happy Path Scenarios
- [ ] Tests are green
